### PR TITLE
Remove mention of contravariance possibly getting scrapped

### DIFF
--- a/src/phantom-data.md
+++ b/src/phantom-data.md
@@ -96,9 +96,7 @@ Here’s a table of all the wonderful ways `PhantomData` could be used:
 | `PhantomData<&'a mut T>`    | variant   | invariant                 |
 | `PhantomData<*const T>`     | -         | variant                   |
 | `PhantomData<*mut T>`       | -         | invariant                 |
-| `PhantomData<fn(T)>`        | -         | contravariant (*)         |
+| `PhantomData<fn(T)>`        | -         | contravariant             |
 | `PhantomData<fn() -> T>`    | -         | variant                   |
 | `PhantomData<fn(T) -> T>`   | -         | invariant                 |
 | `PhantomData<Cell<&'a ()>>` | invariant | -                         |
-
-(*) If contravariance gets scrapped, this would be invariant.


### PR DESCRIPTION
Contravariance is part of stable Rust, and it's a natural outcome of how `fn(T)` interacts with lifetimes, so it's hard to imagine this ever going away.

tl;dr: LONG LIVE CONTRAVARIANCE!