### PR TITLE
Rename `Alloc` to `AllocRef`

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -28,7 +28,7 @@ For instance, a custom implementation of `Box` might write `Drop` like this:
 ```rust
 #![feature(ptr_internals, allocator_api)]
 
-use std::alloc::{Alloc, Global, GlobalAlloc, Layout};
+use std::alloc::{AllocRef, Global, GlobalAlloc, Layout};
 use std::mem;
 use std::ptr::{drop_in_place, NonNull, Unique};
 
@@ -55,7 +55,7 @@ However this wouldn't work:
 ```rust
 #![feature(allocator_api, ptr_internals)]
 
-use std::alloc::{Alloc, Global, GlobalAlloc, Layout};
+use std::alloc::{AllocRef, Global, GlobalAlloc, Layout};
 use std::ptr::{drop_in_place, Unique, NonNull};
 use std::mem;
 
@@ -128,7 +128,7 @@ of Self during `drop` is to use an Option:
 ```rust
 #![feature(allocator_api, ptr_internals)]
 
-use std::alloc::{Alloc, GlobalAlloc, Global, Layout};
+use std::alloc::{AllocRef, GlobalAlloc, Global, Layout};
 use std::ptr::{drop_in_place, Unique, NonNull};
 use std::mem;
 

--- a/src/vec-final.md
+++ b/src/vec-final.md
@@ -9,7 +9,7 @@ use std::ptr::{Unique, NonNull, self};
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::marker::PhantomData;
-use std::alloc::{Alloc, GlobalAlloc, Layout, Global, handle_alloc_error};
+use std::alloc::{AllocRef, GlobalAlloc, Layout, Global, handle_alloc_error};
 
 struct RawVec<T> {
     ptr: Unique<T>,


### PR DESCRIPTION
Required to land https://github.com/rust-lang/rust/pull/68529. Please see that PR for details. The CI is expected to fail until the PR is landed.

EDIT: https://github.com/rust-lang/rust/pull/68529 has landed