### PR TITLE
Fix example in FFI, section NPO

### DIFF
--- a/src/ffi.md
+++ b/src/ffi.md
@@ -648,7 +648,7 @@ fn main() {
 And the code on the C side looks like this:
 
 ```c
-void register(void (*f)(void (*)(int), int)) {
+void register(void (*f)(int (*)(int), int)) {
     ...
 }
 ```


### PR DESCRIPTION
C signature in example (`void (*)(int)`) didn't match the one in the Rust code (`fn(c_int) -> c_int`). Fixed to `int (*)(int)`.