### PR TITLE
(minor) Add backticks around type names

### DIFF
--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -183,8 +183,8 @@ to trying to explain:
 The types with \*'s are the ones we will be focusing on, as they are in
 some sense "fundamental". All the others can be understood by analogy to the others:
 
-* Vec and all other owning pointers and collections follow the same logic as Box
-* Cell and all other interior mutability types follow the same logic as UnsafeCell
+* `Vec` and all other owning pointers and collections follow the same logic as `Box`
+* `Cell` and all other interior mutability types follow the same logic as `UnsafeCell`
 * `*const` follows the logic of `&T`
 * `*mut` follows the logic of `&mut T` (or `UnsafeCell<T>`)
 

--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -183,10 +183,10 @@ to trying to explain:
 The types with \*'s are the ones we will be focusing on, as they are in
 some sense "fundamental". All the others can be understood by analogy to the others:
 
-* `Vec` and all other owning pointers and collections follow the same logic as `Box`
-* `Cell` and all other interior mutability types follow the same logic as `UnsafeCell`
-* `*const` follows the logic of `&T`
-* `*mut` follows the logic of `&mut T` (or `UnsafeCell<T>`)
+* `Vec<T>` and all other owning pointers and collections follow the same logic as `Box<T>`
+* `Cell<T>` and all other interior mutability types follow the same logic as `UnsafeCell<T>`
+* `*const T` follows the logic of `&T`
+* `*mut T` follows the logic of `&mut T` (or `UnsafeCell<T>`)
 
 > NOTE: the *only* source of contravariance in the language is the arguments to
 > a function, which is why it really doesn't come up much in practice. Invoking


### PR DESCRIPTION
Added backticks around type names for consistency of document.