### PR TITLE
Update implementation code of `split_at_mut`

### DIFF
--- a/src/borrow-splitting.md
+++ b/src/borrow-splitting.md
@@ -66,13 +66,15 @@ the implementation requires some unsafety:
 # impl<T> FakeSlice<T> {
 # fn len(&self) -> usize { unimplemented!() }
 # fn as_mut_ptr(&mut self) -> *mut T { unimplemented!() }
-fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
+pub fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
     let len = self.len();
     let ptr = self.as_mut_ptr();
-    assert!(mid <= len);
+
     unsafe {
+        assert!(mid <= len);
+
         (from_raw_parts_mut(ptr, mid),
-         from_raw_parts_mut(ptr.offset(mid as isize), len - mid))
+         from_raw_parts_mut(ptr.add(mid), len - mid))
     }
 }
 # }


### PR DESCRIPTION
Update implementation code of `split_at_mut` to [latest version](https://doc.rust-lang.org/src/core/slice/mod.rs.html#1083-1093)