### PR TITLE
Delete redundant & unprof. lang from transmutes

### DIFF
--- a/src/transmutes.md
+++ b/src/transmutes.md
@@ -18,9 +18,6 @@ boggling.
 * Making a primitive with an invalid value is UB
 * Transmuting between non-repr(C) types is UB
 * Transmuting an & to &mut is UB
-    * Transmuting an & to &mut is *always* UB
-    * No you can't do it
-    * No you're not special
 * Transmuting to a reference without an explicitly provided lifetime
   produces an [unbounded lifetime]
 


### PR DESCRIPTION
These three points don't add anything and they don't belong to professional documentation.