### PR TITLE
Update vec-alloc.md to no longer claim jemalloc backs the Rust heap APIs by default

### DIFF
--- a/src/vec-alloc.md
+++ b/src/vec-alloc.md
@@ -34,7 +34,7 @@ Without this assert, some of our early drafts will do some Very Bad Things.
 
 Next we need to figure out what to actually do when we *do* want space. For
 that, we'll need to use the rest of the heap APIs. These basically allow us to
-talk directly to Rust's allocator (jemalloc by default).
+talk directly to Rust's allocator (libc's `malloc` by default).
 
 We'll also need a way to handle out-of-memory (OOM) conditions. The standard
 library calls `std::alloc::oom()`, which in turn calls the `oom` langitem,


### PR DESCRIPTION
Fixes #229