### PR TITLE
Use isize::MAX directly on type instead of module

### DIFF
--- a/src/vec-alloc.md
+++ b/src/vec-alloc.md
@@ -182,7 +182,7 @@ fn grow(&mut self) {
             // we need to make. We lose the ability to allocate e.g. 2/3rds of
             // the address space with a single Vec of i16's on 32-bit though.
             // Alas, poor Yorick -- I knew him, Horatio.
-            assert!(old_num_bytes <= (::std::isize::MAX as usize) / 2,
+            assert!(old_num_bytes <= (isize::MAX as usize) / 2,
                     "capacity overflow");
 
             let new_num_bytes = old_num_bytes * 2;

--- a/src/vec-final.md
+++ b/src/vec-final.md
@@ -9,7 +9,7 @@ use std::ptr::{Unique, NonNull, self};
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::marker::PhantomData;
-use std::alloc::{AllocRef, GlobalAlloc, Layout, Global, handle_alloc_error};
+use std::alloc::{AllocInit, AllocRef, GlobalAlloc, Layout, Global, handle_alloc_error};
 
 struct RawVec<T> {
     ptr: Unique<T>,
@@ -34,7 +34,7 @@ impl<T> RawVec<T> {
             assert!(elem_size != 0, "capacity overflow");
 
             let (new_cap, ptr) = if self.cap == 0 {
-                let ptr = Global.alloc(Layout::array::<T>(1).unwrap());
+                let ptr = Global.alloc(Layout::array::<T>(1).unwrap(), AllocInit::Uninitialized);
                 (1, ptr)
             } else {
                 let new_cap = 2 * self.cap;

--- a/src/vec-final.md
+++ b/src/vec-final.md
@@ -9,7 +9,15 @@ use std::ptr::{Unique, NonNull, self};
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::marker::PhantomData;
-use std::alloc::{AllocInit, AllocRef, GlobalAlloc, Layout, Global, handle_alloc_error};
+use std::alloc::{
+    AllocInit,
+    AllocRef,
+    Global,
+    GlobalAlloc,
+    Layout,
+    ReallocPlacement,
+    handle_alloc_error
+};
 
 struct RawVec<T> {
     ptr: Unique<T>,
@@ -39,9 +47,11 @@ impl<T> RawVec<T> {
             } else {
                 let new_cap = 2 * self.cap;
                 let c: NonNull<T> = self.ptr.into();
-                let ptr = Global.realloc(c.cast(),
-                                         Layout::array::<T>(self.cap).unwrap(),
-                                         Layout::array::<T>(new_cap).unwrap().size());
+                let ptr = Global.grow(c.cast(),
+                                      Layout::array::<T>(self.cap).unwrap(),
+                                      Layout::array::<T>(new_cap).unwrap().size(),
+                                      ReallocPlacement::MayMove,
+                                      AllocInit::Uninitialized);
                 (new_cap, ptr)
             };
 
@@ -52,7 +62,7 @@ impl<T> RawVec<T> {
                     mem::align_of::<T>(),
                 ))
             }
-            let (ptr, _) = ptr.unwrap();
+            let ptr = ptr.unwrap().ptr;
 
             self.ptr = Unique::new_unchecked(ptr.as_ptr() as *mut _);
             self.cap = new_cap;


### PR DESCRIPTION
It's simpler (shorter) to access `MIN`/`MAX` directly on the integer types now. This repository only had a single instance of this, so the PR is tiny. But it's basically a follow up of https://github.com/rust-lang/rust/pull/69860 to make all documentation consistently use the newest versions of the constants.

r? @dtolnay