### PR TITLE
Use just `std::_` instead of `::std::_`

### DIFF
--- a/src/vec-deref.md
+++ b/src/vec-deref.md
@@ -18,7 +18,7 @@ impl<T> Deref for Vec<T> {
     type Target = [T];
     fn deref(&self) -> &[T] {
         unsafe {
-            ::std::slice::from_raw_parts(self.ptr.as_ptr(), self.len)
+            std::slice::from_raw_parts(self.ptr.as_ptr(), self.len)
         }
     }
 }
@@ -32,7 +32,7 @@ use std::ops::DerefMut;
 impl<T> DerefMut for Vec<T> {
     fn deref_mut(&mut self) -> &mut [T] {
         unsafe {
-            ::std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len)
+            std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len)
         }
     }
 }

--- a/src/vec-final.md
+++ b/src/vec-final.md
@@ -186,7 +186,7 @@ impl<T> Deref for Vec<T> {
     type Target = [T];
     fn deref(&self) -> &[T] {
         unsafe {
-            ::std::slice::from_raw_parts(self.ptr(), self.len)
+            std::slice::from_raw_parts(self.ptr(), self.len)
         }
     }
 }
@@ -194,7 +194,7 @@ impl<T> Deref for Vec<T> {
 impl<T> DerefMut for Vec<T> {
     fn deref_mut(&mut self) -> &mut [T] {
         unsafe {
-            ::std::slice::from_raw_parts_mut(self.ptr(), self.len)
+            std::slice::from_raw_parts_mut(self.ptr(), self.len)
         }
     }
 }


### PR DESCRIPTION
Accessing std this way has been stable since Rust 1.30.0.

It's shorter and simpler (and less ugly IMHO).