### PR TITLE
Rename Unique::empty to Unique::dangling

### DIFF
--- a/src/vec-alloc.md
+++ b/src/vec-alloc.md
@@ -9,8 +9,8 @@ This is perfectly fine because we already have `cap == 0` as our sentinel for no
 allocation. We don't even need to handle it specially in almost any code because
 we usually need to check if `cap > len` or `len > 0` anyway. The recommended
 Rust value to put here is `mem::align_of::<T>()`. Unique provides a convenience
-for this: `Unique::empty()`. There are quite a few places where we'll
-want to use `empty` because there's no real allocation to talk about but
+for this: `Unique::dangling()`. There are quite a few places where we'll
+want to use `dangling` because there's no real allocation to talk about but
 `null` would make the compiler do bad things.
 
 So:
@@ -23,7 +23,7 @@ use std::mem;
 impl<T> Vec<T> {
     fn new() -> Self {
         assert!(mem::size_of::<T>() != 0, "We're not ready to handle ZSTs");
-        Vec { ptr: Unique::empty(), len: 0, cap: 0 }
+        Vec { ptr: Unique::dangling(), len: 0, cap: 0 }
     }
 }
 ```

--- a/src/vec-final.md
+++ b/src/vec-final.md
@@ -29,8 +29,8 @@ impl<T> RawVec<T> {
         // !0 is usize::MAX. This branch should be stripped at compile time.
         let cap = if mem::size_of::<T>() == 0 { !0 } else { 0 };
 
-        // Unique::empty() doubles as "unallocated" and "zero-sized allocation"
-        RawVec { ptr: Unique::empty(), cap: cap }
+        // Unique::dangling() doubles as "unallocated" and "zero-sized allocation"
+        RawVec { ptr: Unique::dangling(), cap: cap }
     }
 
     fn grow(&mut self) {

--- a/src/vec-raw.md
+++ b/src/vec-raw.md
@@ -18,7 +18,7 @@ struct RawVec<T> {
 impl<T> RawVec<T> {
     fn new() -> Self {
         assert!(mem::size_of::<T>() != 0, "TODO: implement ZST support");
-        RawVec { ptr: Unique::empty(), cap: 0 }
+        RawVec { ptr: Unique::dangling(), cap: 0 }
     }
 
     // unchanged from Vec

--- a/src/vec-zsts.md
+++ b/src/vec-zsts.md
@@ -19,7 +19,7 @@ RawValIter and RawVec respectively. How mysteriously convenient.
 ## Allocating Zero-Sized Types
 
 So if the allocator API doesn't support zero-sized allocations, what on earth
-do we store as our allocation? `Unique::empty()` of course! Almost every operation
+do we store as our allocation? `Unique::dangling()` of course! Almost every operation
 with a ZST is a no-op since ZSTs have exactly one value, and therefore no state needs
 to be considered to store or load them. This actually extends to `ptr::read` and
 `ptr::write`: they won't actually look at the pointer at all. As such we never need
@@ -38,8 +38,8 @@ impl<T> RawVec<T> {
         // !0 is usize::MAX. This branch should be stripped at compile time.
         let cap = if mem::size_of::<T>() == 0 { !0 } else { 0 };
 
-        // Unique::empty() doubles as "unallocated" and "zero-sized allocation"
-        RawVec { ptr: Unique::empty(), cap: cap }
+        // Unique::dangling() doubles as "unallocated" and "zero-sized allocation"
+        RawVec { ptr: Unique::dangling(), cap: cap }
     }
 
     fn grow(&mut self) {


### PR DESCRIPTION
Renamed in https://github.com/rust-lang/rust/pull/71597.  Fixes toolstate.
