### PR TITLE
Data Race definition should be more precise

### DIFF
--- a/src/races.md
+++ b/src/races.md
@@ -3,8 +3,8 @@
 Safe Rust guarantees an absence of data races, which are defined as:
 
 * two or more threads concurrently accessing a location of memory
-* one of them is a write
-* one of them is unsynchronized
+* one or more of them is a write
+* one or more of them is unsynchronized
 
 A data race has Undefined Behavior, and is therefore impossible to perform
 in Safe Rust. Data races are *mostly* prevented through Rust's ownership system:


### PR DESCRIPTION
"one of them is a write" did not seem right to me. Doesn't generalise to the case with two concurrent threads writing to shared memory. [Related Wikipedia article](https://en.wikipedia.org/wiki/Race_condition#Example_definitions_of_data_races_in_particular_concurrency_models)