### PR TITLE
Adds compiler error for example in Limits of Lifetimes

### DIFF
--- a/src/lifetime-mismatch.md
+++ b/src/lifetime-mismatch.md
@@ -74,7 +74,7 @@ care about, but the lifetime system is too coarse-grained to handle that.
 
 # Improperly reduced borrows
 
-This currently fails to compile, because Rust doesn't understand that the borrow
+The following code fails to compile, because Rust doesn't understand that the borrow
 is no longer needed and conservatively falls back to using a whole scope for it.
 This will eventually get fixed.
 

--- a/src/lifetime-mismatch.md
+++ b/src/lifetime-mismatch.md
@@ -96,5 +96,29 @@ where
 }
 ```
 
+Because of the lifetime restrictions imposed, `&mut map`'s lifetime
+overlaps other mutable borrows, resulting in a compile error:
+
+```text
+error[E0499]: cannot borrow `*map` as mutable more than once at a time
+  --> src/main.rs:12:13
+   |
+4  |   fn get_default<'m, K, V>(map: &'m mut HashMap<K, V>, key: K) -> &'m mut V
+   |                  -- lifetime `'m` defined here
+...
+9  |       match map.get_mut(&key) {
+   |       -     --- first mutable borrow occurs here
+   |  _____|
+   | |
+10 | |         Some(value) => value,
+11 | |         None => {
+12 | |             map.insert(key.clone(), V::default());
+   | |             ^^^ second mutable borrow occurs here
+13 | |             map.get_mut(&key).unwrap()
+14 | |         }
+15 | |     }
+   | |_____- returning this value requires that `*map` is borrowed for `'m`
+```
+
 
 [ex2]: lifetimes.html#example-aliasing-a-mutable-reference


### PR DESCRIPTION
Hello!

I wanted to see what the compiler error actually was for the given example under "Improperly reduced borrows" so I added it for future readers to see