### PR TITLE
Fix alloc link in exotic-sizes for local docs

### DIFF
--- a/src/exotic-sizes.md
+++ b/src/exotic-sizes.md
@@ -118,7 +118,7 @@ references, must be non-null and suitably aligned. Dereferencing a null or
 unaligned pointer to a ZST is [undefined behavior][ub], just like for any other
 type.
 
-[alloc]: https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.alloc
+[alloc]: ../std/alloc/trait.GlobalAlloc.html#tymethod.alloc
 [ub]: what-unsafe-does.html
 
 


### PR DESCRIPTION
This changes `https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.alloc` to `../std/alloc/trait.GlobalAlloc.html#tymethod.alloc` so that it uses the local docs installation if the page is viewed with the local docs, instead of https://doc.rust-lang.org.