### PR TITLE
Add example of thinking about Send/Sync's soundness

### DIFF
--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -93,7 +93,7 @@ struct Carton<T>(ptr::NonNull<T>);
 impl<T> Carton<T> {
     pub fn new(value: T) -> Self {
         // Allocate enough memory on the heap to store one T.
-        assert_ne!(size_of::<T>(), 0, "Zero-sized types are out of the scope of this example);
+        assert_ne!(size_of::<T>(), 0, "Zero-sized types are out of the scope of this example");
         let memptr: *mut c_void = ptr::null_mut();
         unsafe {
             let ret = libc::posix_memalign(

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -108,7 +108,7 @@ impl<T> Carton<T> {
         let mut ptr = unsafe {
             // Safety: memptr is dereferenceable because we created it from a
             // reference and have exclusive access.
-            NonNull::new(memptr.cast::<T>())
+            ptr::NonNull::new(memptr.cast::<T>())
                 .expect("Guaranteed non-null if posix_memalign returns 0")
         };
 

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -93,10 +93,11 @@ struct Carton<T>(NonNull<T>);
 impl<T> Carton<T> {
     pub fn new(value: T) -> Self {
         // Allocate enough memory on the heap to store one T.
-        let memptr = &mut null_mut() as *mut *mut T;
+        assert_ne!(size_of::<T>(), 0, "Zero-sized types are out of the scope of this example);
+        let memptr: *mut c_void = ptr::null_mut();
         unsafe {
             let ret = libc::posix_memalign(
-                memptr as *mut *mut c_void,
+                &mut memptr,
                 align_of::<T>(),
                 size_of::<T>()
             );
@@ -107,7 +108,7 @@ impl<T> Carton<T> {
         let mut ptr = unsafe {
             // Safety: memptr is dereferenceable because we created it from a
             // reference and have exclusive access.
-            NonNull::new(*memptr)
+            NonNull::new(memptr.cast::<T>())
                 .expect("Guaranteed non-null if posix_memalign returns 0")
         };
 

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -126,8 +126,10 @@ to access it. [`Box`][box-doc] implements [`Deref`][deref-doc] and
 [`DerefMut`][deref-mut-doc] so that you can access the inner value. Let's do
 that.
 
-```rust,ignore
+```rust
 use std::ops::{Deref, DerefMut};
+
+# struct Carton<T>(std::ptr::NonNull<T>);
 
 impl<T> Deref for Carton<T> {
     type Target = T;
@@ -165,7 +167,8 @@ safely be Send unless it shares mutable state with something else without
 enforcing exclusive access to it. Each `Carton` has a unique pointer, so
 we're good.
 
-```rust,ignore
+```rust
+# struct Carton<T>(std::ptr::NonNull<T>);
 // Safety: No one besides us has the raw pointer, so we can safely transfer the
 // Carton to another thread if T can be safely transferred.
 unsafe impl<T> Send for Carton<T> where T: Send {}
@@ -178,7 +181,8 @@ write to the pointer, and the borrow checker enforces that mutable
 references must be exclusive, there are no soundness issues making `Carton`
 sync either.
 
-```rust,ignore
+```rust
+# struct Carton<T>(std::ptr::NonNull<T>);
 // Safety: Our implementation of DerefMut requires writers to mutably borrow the
 // Carton, so the borrow checker will only let us have references to the Carton
 // on multiple threads if no one has a mutable reference to the Carton. This

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -86,9 +86,9 @@ to the heap.
 
 ```rust,ignore
 use std::mem::size_of;
-use std::ptr::NonNull;
+use std::ptr;
 
-struct Carton<T>(NonNull<T>);
+struct Carton<T>(ptr::NonNull<T>);
 
 impl<T> Carton<T> {
     pub fn new(value: T) -> Self {

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -209,8 +209,8 @@ unsafe impl<T> Send for Carton<T> where Box<T>: Send {}
 Right now Carton<T> has a memory leak, as it never frees the memory it allocates.
 Once we fix that we have a new requirement we have to ensure we meet to be Send:
 we need to know `free` can be called on a pointer that was yielded by an
-allocation done on another thread. This is the case for `libc::free`, so we can
-still be Send.
+allocation done on another thread. We can check this is true in the docs for
+[`libc::free`][libc-free-docs].
 
 ```rust,ignore
 impl<T> Drop for Carton<T> {
@@ -227,7 +227,7 @@ A nice example where this does not happen is with a MutexGuard: notice how
 [uses libraries][mutex-guard-not-send-comment] that require you to ensure you
 don't try to free a lock that you acquired in a different thread. If you were
 able to Send a MutexGuard to another thread the destructor would run in the
-thread you sent it to, violating the requirement. MutexGuard can still be sync
+thread you sent it to, violating the requirement. MutexGuard can still be Sync
 because all you can send to another thread is an `&MutexGuard` and dropping a
 reference does nothing.
 
@@ -241,3 +241,4 @@ only to data races?
 [deref-mut-doc]: https://doc.rust-lang.org/core/ops/trait.DerefMut.html
 [mutex-guard-not-send-docs-rs]: https://doc.rust-lang.org/std/sync/struct.MutexGuard.html#impl-Send
 [mutex-guard-not-send-comment]: https://github.com/rust-lang/rust/issues/23465#issuecomment-82730326
+[libc-free-docs]: https://linux.die.net/man/3/free

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -205,11 +205,7 @@ TODO: better explain what can or can't be Send or Sync. Sufficient to appeal
 only to data races?
 
 [unsafe traits]: safe-unsafe-meaning.html
-
 [box-doc]: https://doc.rust-lang.org/std/boxed/struct.Box.html
-
 [box-is-special]: https://manishearth.github.io/blog/2017/01/10/rust-tidbits-box-is-special/
-
 [deref-doc]: https://doc.rust-lang.org/core/ops/trait.Deref.html
-
 [deref-mut-doc]: https://doc.rust-lang.org/core/ops/trait.DerefMut.html

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -162,7 +162,7 @@ impl<T> DerefMut for Carton<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
             // Safety: The pointer is aligned, initialized, and dereferenceable
-            //   by the logic in [`Self::new]. We require writers to mutably
+            //   by the logic in [`Self::new`]. We require writers to mutably
             //   borrow the Carton, and the lifetime of the return value is
             //   elided to the lifetime of the input. This means the borrow
             //   checker will enforce that no one else can access the contents

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -74,6 +74,8 @@ of their pervasive use of raw pointers to manage allocations and complex ownersh
 Similarly, most iterators into these collections are Send and Sync because they
 largely behave like an `&` or `&mut` into the collection.
 
+## Example
+
 [`Box`][box-doc] is implemented as it's own special intrinsic type by the
 compiler for [various reasons][box-is-special], but we can implement something
 with similar-ish behavior ourselves to see an example of when it is sound to

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -82,7 +82,7 @@ implement Send and Sync. Let's call it a `Carton`.
 We start by writing code to take a value allocated on the stack and transfer it
 to the heap.
 
-```rust
+```rust,ignore
 use std::mem::size_of;
 use std::ptr::NonNull;
 
@@ -114,7 +114,7 @@ to access it. [`Box`][box-doc] implements [`Deref`][deref-doc] and
 [`DerefMut`][deref-mut-doc] so that you can access the inner value. Let's do
 that.
 
-```rust
+```rust,ignore
 use std::ops::{Deref, DerefMut};
 
 impl<T> Deref for Carton<T> {
@@ -153,7 +153,7 @@ safely be Send unless it shares mutable state with something else without
 enforcing exclusive access to it. Each `Carton` has a unique pointer, so
 we're good.
 
-```rust
+```rust,ignore
 // Safety: No one besides us has the raw pointer, so we can safely transfer the
 // Carton to another thread.
 unsafe impl<T> Send for Carton<T> {}
@@ -166,7 +166,7 @@ write to the pointer, and the borrow checker enforces that mutable
 references must be exclusive, there are no soundness issues making `Carton`
 sync either.
 
-```rust
+```rust,ignore
 // Safety: Our implementation of DerefMut requires writers to mutably borrow the
 // Carton, so the borrow checker will only let us have references to the Carton
 // on multiple threads if no one has a mutable reference to the Carton.

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -173,7 +173,7 @@ impl<T> DerefMut for Carton<T> {
 }
 ```
 
-Finally, lets think about whether our `Carton` is Send and Sync. Something can
+Finally, let's think about whether our `Carton` is Send and Sync. Something can
 safely be Send unless it shares mutable state with something else without
 enforcing exclusive access to it. Each `Carton` has a unique pointer, so
 we're good.

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -84,10 +84,16 @@ implement Send and Sync. Let's call it a `Carton`.
 We start by writing code to take a value allocated on the stack and transfer it
 to the heap.
 
-```rust,ignore
-use std::mem::size_of;
-use std::ptr;
-
+```rust
+# mod libc {
+#     pub use ::std::os::raw::{c_int, c_void, size_t};
+#     extern "C" { pub fn posix_memalign(memptr: *mut *mut c_void, align: size_t, size: size_t) -> c_int; }
+# }
+use std::{
+    mem::{align_of, size_of},
+    ptr,
+};
+use libc::c_void;
 struct Carton<T>(ptr::NonNull<T>);
 
 impl<T> Carton<T> {

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -214,7 +214,7 @@ sort of Box would be Send, which in this case is the same as saying T is Send.
 unsafe impl<T> Send for Carton<T> where Box<T>: Send {}
 ```
 
-Right now Carton<T> has a memory leak, as it never frees the memory it allocates.
+Right now `Carton<T>` has a memory leak, as it never frees the memory it allocates.
 Once we fix that we have a new requirement we have to ensure we meet to be Send:
 we need to know `free` can be called on a pointer that was yielded by an
 allocation done on another thread. We can check this is true in the docs for

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -141,7 +141,7 @@ that.
 use std::ops::{Deref, DerefMut};
 
 # struct Carton<T>(std::ptr::NonNull<T>);
-
+#
 impl<T> Deref for Carton<T> {
     type Target = T;
 

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -76,7 +76,7 @@ largely behave like an `&` or `&mut` into the collection.
 
 [`Box`][box-doc] is implemented as it's own special intrinsic type by the
 compiler for [various reasons][box-is-special], but we can implement something
-with similar-ish behaviour ourselves to see an example of when it is sound to
+with similar-ish behavior ourselves to see an example of when it is sound to
 implement Send and Sync. Let's call it a `Carton`.
 
 We start by writing code to take a value allocated on the stack and transfer it

--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -186,14 +186,16 @@ sync either.
 
 ```rust
 # struct Carton<T>(std::ptr::NonNull<T>);
-// Safety: Our implementation of DerefMut requires writers to mutably borrow the
-// Carton, so the borrow checker will only let us have references to the Carton
-// on multiple threads if no one has a mutable reference to the Carton. This
-// means we are Sync if T is Sync.
+// Safety: Since there exists a public way to go from a `&Carton<T>` to a `&T`
+// in an unsynchronized fashion (such as `Deref`), then `Carton<T>` can't be
+// `Sync` if `T` isn't.
+// Conversely, `Carton` itself does not use any interior mutability whatsoever:
+// all the mutations are performed through an exclusive reference (`&mut`). This
+// means it suffices that `T` be `Sync` for `Carton<T>` to be `Sync`:
 unsafe impl<T> Sync for Carton<T> where T: Sync  {}
 ```
 
-When we assert our type is Send and Sync we need to enforce that every
+When we assert our type is Send and Sync we usually need to enforce that every
 contained type is Send and Sync. When writing custom types that behave like
 standard library types we can assert that we have the same requirements.
 For example, the following code asserts that a Carton is Send if the same


### PR DESCRIPTION
Add an example of thinking through whether it is sound to implement Send + Sync for a custom type that wraps a raw pointer.

I read the existing docs and was confused about whether I could implement Send + Sync for a type I wrote that wraps a c-style array. Kixiron, InfernoDeity, Talchas, and HeroicKatora on #black-magic helped me understand Send and Sync better. This example is based on the advice they gave me. I've made lots of changes, so any errors are probably mine.