### PR TITLE
Use pointer 'add' instead of 'offset'

### DIFF
--- a/src/exception-safety.md
+++ b/src/exception-safety.md
@@ -48,7 +48,7 @@ impl<T: Clone> Vec<T> {
             self.set_len(self.len() + to_push.len());
 
             for (i, x) in to_push.iter().enumerate() {
-                self.ptr().offset(i as isize).write(x.clone());
+                self.ptr().add(i).write(x.clone());
             }
         }
     }
@@ -58,7 +58,7 @@ impl<T: Clone> Vec<T> {
 We bypass `push` in order to avoid redundant capacity and `len` checks on the
 Vec that we definitely know has capacity. The logic is totally correct, except
 there's a subtle problem with our code: it's not exception-safe! `set_len`,
-`offset`, and `write` are all fine; `clone` is the panic bomb we over-looked.
+`add`, and `write` are all fine; `clone` is the panic bomb we over-looked.
 
 Clone is completely out of our control, and is totally free to panic. If it
 does, our function will exit early with the length of the Vec set too large. If

--- a/src/vec-drain.md
+++ b/src/vec-drain.md
@@ -46,7 +46,7 @@ impl<T> RawValIter<T> {
                 // information to LLVM via GEP.
                 slice.as_ptr()
             } else {
-                slice.as_ptr().offset(slice.len() as isize)
+                slice.as_ptr().add(slice.len())
             }
         }
     }

--- a/src/vec-final.md
+++ b/src/vec-final.md
@@ -111,7 +111,7 @@ impl<T> Vec<T> {
         }
 
         unsafe {
-            ptr::write(self.ptr().offset(self.len as isize), elem);
+            ptr::write(self.ptr().add(self.len), elem);
         }
 
         // Can't overflow, we'll OOM first.
@@ -123,7 +123,7 @@ impl<T> Vec<T> {
             None
         } else {
             self.len -= 1;
-            unsafe { Some(ptr::read(self.ptr().offset(self.len as isize))) }
+            unsafe { Some(ptr::read(self.ptr().add(self.len))) }
         }
     }
 
@@ -135,11 +135,11 @@ impl<T> Vec<T> {
 
         unsafe {
             ptr::copy(
-                self.ptr().offset(index as isize),
-                self.ptr().offset(index as isize + 1),
+                self.ptr().add(index),
+                self.ptr().add(index + 1),
                 self.len - index,
             );
-            ptr::write(self.ptr().offset(index as isize), elem);
+            ptr::write(self.ptr().add(index), elem);
             self.len += 1;
         }
     }
@@ -148,10 +148,10 @@ impl<T> Vec<T> {
         assert!(index < self.len, "index out of bounds");
         unsafe {
             self.len -= 1;
-            let result = ptr::read(self.ptr().offset(index as isize));
+            let result = ptr::read(self.ptr().add(index));
             ptr::copy(
-                self.ptr().offset(index as isize + 1),
-                self.ptr().offset(index as isize),
+                self.ptr().add(index + 1),
+                self.ptr().add(index),
                 self.len - index,
             );
             result
@@ -222,7 +222,7 @@ impl<T> RawValIter<T> {
             } else if slice.len() == 0 {
                 slice.as_ptr()
             } else {
-                slice.as_ptr().offset(slice.len() as isize)
+                slice.as_ptr().add(slice.len())
             },
         }
     }

--- a/src/vec-insert-remove.md
+++ b/src/vec-insert-remove.md
@@ -21,10 +21,10 @@ pub fn insert(&mut self, index: usize, elem: T) {
 
     unsafe {
         // ptr::copy(src, dest, len): "copy from src to dest len elems"
-        ptr::copy(self.ptr.as_ptr().offset(index as isize),
-                  self.ptr.as_ptr().offset(index as isize + 1),
+        ptr::copy(self.ptr.as_ptr().add(index),
+                  self.ptr.as_ptr().add(index + 1),
                   self.len - index);
-        ptr::write(self.ptr.as_ptr().offset(index as isize), elem);
+        ptr::write(self.ptr.as_ptr().add(index), elem);
         self.len += 1;
     }
 }
@@ -39,9 +39,9 @@ pub fn remove(&mut self, index: usize) -> T {
     assert!(index < self.len, "index out of bounds");
     unsafe {
         self.len -= 1;
-        let result = ptr::read(self.ptr.as_ptr().offset(index as isize));
-        ptr::copy(self.ptr.as_ptr().offset(index as isize + 1),
-                  self.ptr.as_ptr().offset(index as isize),
+        let result = ptr::read(self.ptr.as_ptr().add(index));
+        ptr::copy(self.ptr.as_ptr().add(index + 1),
+                  self.ptr.as_ptr().add(index),
                   self.len - index);
         result
     }

--- a/src/vec-into-iter.md
+++ b/src/vec-into-iter.md
@@ -74,7 +74,7 @@ impl<T> Vec<T> {
                     // can't offset off this pointer, it's not allocated!
                     ptr.as_ptr()
                 } else {
-                    ptr.as_ptr().offset(len as isize)
+                    ptr.as_ptr().add(len)
                 },
                 _marker: PhantomData,
             }

--- a/src/vec-push-pop.md
+++ b/src/vec-push-pop.md
@@ -22,7 +22,7 @@ pub fn push(&mut self, elem: T) {
     if self.len == self.cap { self.grow(); }
 
     unsafe {
-        ptr::write(self.ptr.as_ptr().offset(self.len as isize), elem);
+        ptr::write(self.ptr.as_ptr().add(self.len), elem);
     }
 
     // Can't fail, we'll OOM first.
@@ -48,7 +48,7 @@ pub fn pop(&mut self) -> Option<T> {
     } else {
         self.len -= 1;
         unsafe {
-            Some(ptr::read(self.ptr.as_ptr().offset(self.len as isize)))
+            Some(ptr::read(self.ptr.as_ptr().add(self.len)))
         }
     }
 }

--- a/src/vec-raw.md
+++ b/src/vec-raw.md
@@ -142,7 +142,7 @@ impl<T> Vec<T> {
 
             IntoIter {
                 start: buf.ptr.as_ptr(),
-                end: buf.ptr.as_ptr().offset(len as isize),
+                end: buf.ptr.as_ptr().add(len),
                 _buf: buf,
             }
         }

--- a/src/vec-zsts.md
+++ b/src/vec-zsts.md
@@ -123,7 +123,7 @@ impl<T> RawValIter<T> {
             } else if slice.len() == 0 {
                 slice.as_ptr()
             } else {
-                slice.as_ptr().offset(slice.len() as isize)
+                slice.as_ptr().add(slice.len())
             },
         }
     }

--- a/src/working-with-unsafe.md
+++ b/src/working-with-unsafe.md
@@ -71,7 +71,7 @@ impl<T> Vec<T> {
             self.reallocate();
         }
         unsafe {
-            ptr::write(self.ptr.offset(self.len as isize), elem);
+            ptr::write(self.ptr.add(self.len), elem);
             self.len += 1;
         }
     }


### PR DESCRIPTION
This a clean-up to use the [`add`](https://doc.rust-lang.org/std/primitive.pointer.html#method.add) method on raw pointers where applicable, i.e., where [`offset`](https://doc.rust-lang.org/std/primitive.pointer.html#method.offset) was being used with a cast on the index from `usize` to `isize`. This implements a [suggestion](https://github.com/rust-lang/nomicon/pull/223#discussion_r615133425) from Amanieu.