### PR TITLE
Add an incomplete warning to the top page

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -4,6 +4,7 @@ title = "The Rustonomicon"
 description = "The Dark Arts of Advanced and Unsafe Rust Programming"
 
 [output.html]
+additional-css = ["theme/nomicon.css"]
 git-repository-url = "https://github.com/rust-lang/nomicon"
 
 [output.html.redirect]

--- a/src/intro.md
+++ b/src/intro.md
@@ -1,5 +1,16 @@
 # The Rustonomicon
 
+<div class="warning">
+
+Warning:
+This book is incomplete.
+Documenting everything and rewriting outdated parts take a while.
+See the [issue tracker] to check what's missing/outdated, and if there are any mistakes or ideas that haven't been reported, feel free to open a new issue there.
+
+</div>
+
+[issue tracker]: https://github.com/rust-lang/nomicon/issues
+
 ## The Dark Arts of Unsafe Rust
 
 > THE KNOWLEDGE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF UNLEASHING INDESCRIBABLE HORRORS THAT SHATTER YOUR PSYCHE AND SET YOUR MIND ADRIFT IN THE UNKNOWABLY INFINITE COSMOS.

--- a/theme/nomicon.css
+++ b/theme/nomicon.css
@@ -1,0 +1,40 @@
+/*
+Taken from the reference.
+Warnings and notes:
+Write the <div>s on their own line. E.g.
+<div class="warning">
+Warning: This is bad!
+</div>
+*/
+main .warning p {
+    padding: 10px 20px;
+    margin: 20px 0;
+}
+
+main .warning p::before {
+    content: "⚠️ ";
+}
+
+.light main .warning p,
+.rust main .warning p {
+    border: 2px solid red;
+    background: #ffcece;
+}
+
+.rust main .warning p {
+    /* overrides previous declaration */
+    border-color: #961717;
+}
+
+.coal main .warning p,
+.navy main .warning p,
+.ayu main .warning p {
+    background: #542626
+}
+
+/* Make the links higher contrast on dark themes */
+.coal main .warning p a,
+.navy main .warning p a,
+.ayu main .warning p a {
+    color: #80d0d0
+}


### PR DESCRIPTION
Since we currently have a lot of outdated/missing content, it makes sense to show a warning like the reference.