### PR TITLE
Removed unecessary #[repr(C)] attribute

### DIFF
--- a/src/ffi.md
+++ b/src/ffi.md
@@ -310,7 +310,6 @@ referenced Rust object.
 Rust code:
 
 ```rust,no_run
-#[repr(C)]
 struct RustObject {
     a: i32,
     // Other members...


### PR DESCRIPTION
The #[repr(C)] attribute on the callback example is not necessary, since the type is not used from the C code.