### PR TITLE
Change code for `into_iter` on the `RawVec` section for consistency/soundness

### DIFF
--- a/src/vec/vec-raw.md
+++ b/src/vec/vec-raw.md
@@ -145,7 +145,12 @@ impl<T> Vec<T> {
 
             IntoIter {
                 start: buf.ptr.as_ptr(),
-                end: buf.ptr.as_ptr().add(len),
+                end: if buf.cap == 0 {
+                    // can't offset off of a pointer unless it's part of an allocation
+                    buf.ptr.as_ptr()
+                } else {
+                    buf.ptr.as_ptr().add(len)
+                },
                 _buf: buf,
             }
         }


### PR DESCRIPTION
Just making this consistent with https://github.com/rust-lang/nomicon/blob/master/src/vec/vec-into-iter.md for the section about creating the `IntoIter` to avoid offsetting a dangling pointer.