### PR TITLE
update lifetime-elision to show what elided code under `rust_2018_idi…

### DIFF
--- a/src/lifetime-elision.md
+++ b/src/lifetime-elision.md
@@ -63,5 +63,6 @@ fn args<T: ToCStr>(&mut self, args: &[T]) -> &mut Command                  // el
 fn args<'a, 'b, T: ToCStr>(&'a mut self, args: &'b [T]) -> &'a mut Command // expanded
 
 fn new(buf: &mut [u8]) -> BufWriter;                    // elided
+fn new(buf: &mut [u8]) -> BufWriter<'_>;                // elided (with `rust_2018_idioms`)
 fn new<'a>(buf: &'a mut [u8]) -> BufWriter<'a>          // expanded
 ```


### PR DESCRIPTION
…oms` looks like

This was a bit confusing for me to read, as it was using an old style of rust that I am not used to
Unfortunately, this lint group isn't on by default, but I think `elided_lifetimes_in_paths` may be on track to be deny-by-default in edition 2021?