### PR TITLE
Document thiscall abi

### DIFF
--- a/src/ffi.md
+++ b/src/ffi.md
@@ -516,6 +516,7 @@ are:
 * `aapcs`
 * `cdecl`
 * `fastcall`
+* `thiscall`
 * `vectorcall`
 This is currently hidden behind the `abi_vectorcall` gate and is subject to change.
 * `Rust`


### PR DESCRIPTION
Tracking issue: rust-lang/rust#42202

This is blocked on the stabilization of `thiscall_abi`.