### PR TITLE
doc: clarify `thread::scoped::JoinGuard` chapter

### DIFF
--- a/src/leaking.md
+++ b/src/leaking.md
@@ -176,6 +176,12 @@ horribly degenerate. Also *oh my gosh* it's such a ridiculous corner case.
 
 ## thread::scoped::JoinGuard
 
+> Note: This API has already been removed from std, for more information
+> you may refer [issue #24292](https://github.com/rust-lang/rust/issues/24292).
+>
+> We still remain this chapter here because we think this example is still
+> important, regardless of if it is still in std.
+
 The thread::scoped API intended to allow threads to be spawned that reference
 data on their parent's stack without any synchronization over that data by
 ensuring the parent joins the thread before any of the shared data goes out


### PR DESCRIPTION
Clarify that `thread::scoped::JoinGuard` has been removed from std, and why we still remain this chapter here per #57 .