### PR TITLE
Update rc decrement snipped

### DIFF
--- a/src/arc-mutex/arc-drop.md
+++ b/src/arc-mutex/arc-drop.md
@@ -27,7 +27,7 @@ the last reference to the data).
 
 <!-- ignore: simplified code -->
 ```rust,ignore
-if inner.rc.fetch_sub(1, Ordering::Relaxed) != 1 {
+if inner.rc.fetch_sub(1, Ordering::Release) != 1 {
     return;
 }
 ```


### PR DESCRIPTION
The atomic decrement to `rc` should be performed with an ordering of `Ordering::Release` rather than `ordering::Relaxed` to interact correctly with the fence. The code in the full `Drop` implementation at the bottom of the section is correct.