### PR TITLE
Fix typo with respect to dangling pointer

### DIFF
--- a/src/what-unsafe-does.md
+++ b/src/what-unsafe-does.md
@@ -48,7 +48,7 @@ A reference/pointer is "dangling" if it is null or not all of the bytes it
 points to are part of the same allocation (so in particular they all have to be
 part of *some* allocation). The span of bytes it points to is determined by the
 pointer value and the size of the pointee type. As a consequence, if the span is
-empty, "dangling" is the same as "non-null". Note that slices and strings point
+empty, "dangling" is the same as "null". Note that slices and strings point
 to their entire range, so it's important that the length metadata is never too
 large (in particular, allocations and therefore slices and strings cannot be
 bigger than `isize::MAX` bytes). If for some reason this is too cumbersome,


### PR DESCRIPTION
It seems to be typo in explaining about dangling pointer