### PR TITLE
Clarify that drop flag fields only apply to older Rust versions

### DIFF
--- a/src/drop-flags.md
+++ b/src/drop-flags.md
@@ -79,5 +79,5 @@ if condition {
 }
 ```
 
-The drop flags are tracked on the stack. In old Rust versions, drop flags were
-stashed in a hidden field of types that implement Drop.
+The drop flags are tracked on the stack.
+In old Rust versions, drop flags were stashed in a hidden field of types that implement `Drop`.

--- a/src/drop-flags.md
+++ b/src/drop-flags.md
@@ -79,5 +79,5 @@ if condition {
 }
 ```
 
-The drop flags are tracked on the stack and no longer stashed in types that
-implement drop.
+The drop flags are tracked on the stack. In old Rust versions, drop flags were
+stashed in a hidden field of types that implement Drop.


### PR DESCRIPTION
This sentence originally confused me and it took me a while to realize that it was referring to an older Rust version rather than some edge case of drop flags in the current Rust version.

Perhaps it might be even better to name the specific Rust version where drop flags were moved out of Drop types and onto the stack. I believe that's tied to MIR, but I haven't managed to confirm about a specific Rust version in regards to the drop flags.