### PR TITLE
Fix typo / type error in FFI code example

### DIFF
--- a/src/ffi.md
+++ b/src/ffi.md
@@ -709,7 +709,7 @@ fn main() {
 And the code on the C side looks like this:
 
 ```c
-void register(void (*f)(int (*)(int), int)) {
+void register(int (*f)(int (*)(int), int)) {
     ...
 }
 ```


### PR DESCRIPTION
There's a discrepancy between the C code and the Rust code that calls it.

The Rust callback produces a return code: `fn(fn(int) -> int, int) -> int`,
but the C callback returns nothing: `void (*)(int (*)(int), int)`.