### PR TITLE
Clarify repr(transparent) in other-reprs

### DIFF
--- a/src/other-reprs.md
+++ b/src/other-reprs.md
@@ -63,7 +63,7 @@ whole struct is guaranteed to be the same as that one field.
 The goal is to make it possible to transmute between the single field and the
 struct. An example of that is [`UnsafeCell`], which can be transmuted into
 the type it wraps ([`UnsafeCell`] also uses the unstable [no_niche][no-niche-pull],
-so it's ABI is not actually guaranteed to be the same when nested in other types).
+so its ABI is not actually guaranteed to be the same when nested in other types).
 
 Also, passing the struct through FFI where the inner field type is expected on
 the other side is guaranteed to work. In particular, this is necessary for `struct

--- a/src/other-reprs.md
+++ b/src/other-reprs.md
@@ -62,11 +62,16 @@ whole struct is guaranteed to be the same as that one field.
 
 The goal is to make it possible to transmute between the single field and the
 struct. An example of that is [`UnsafeCell`], which can be transmuted into
-the type it wraps.
+the type it wraps ([`UnsafeCell`] also uses the unstable [no_niche][no-niche-pull],
+so it's ABI is not actually guaranteed to be the same when nested in other types).
 
 Also, passing the struct through FFI where the inner field type is expected on
 the other side is guaranteed to work. In particular, this is necessary for `struct
 Foo(f32)` to always have the same ABI as `f32`.
+
+This repr is only considered part of the public ABI of a type if either the single
+field is pub, or if it's layout is documented in prose. Otherwise, the layout should
+not be relied upon by other crates.
 
 More details are in the [RFC][rfc-transparent].
 
@@ -153,3 +158,4 @@ This is a modifier on `repr(C)` and `repr(Rust)`. It is incompatible with
 [really-tagged]: https://github.com/rust-lang/rfcs/blob/master/text/2195-really-tagged-unions.md
 [rust-bindgen]: https://rust-lang.github.io/rust-bindgen/
 [cbindgen]: https://github.com/eqrion/cbindgen
+[no-niche-pull]: https://github.com/rust-lang/rust/pull/68491

--- a/src/other-reprs.md
+++ b/src/other-reprs.md
@@ -70,7 +70,7 @@ the other side is guaranteed to work. In particular, this is necessary for `stru
 Foo(f32)` to always have the same ABI as `f32`.
 
 This repr is only considered part of the public ABI of a type if either the single
-field is pub, or if it's layout is documented in prose. Otherwise, the layout should
+field is `pub`, or if its layout is documented in prose. Otherwise, the layout should
 not be relied upon by other crates.
 
 More details are in the [RFC][rfc-transparent].


### PR DESCRIPTION
This clarifies that UnsafeCell is not just repr(transparent), since it does not propagate niches the same as it's inner type, and also mentions when it can be relied on by other crates. 

For some discussion on that second point, see this issue https://github.com/rust-lang/rust/issues/90435
