### PR TITLE
Make C code more recognizably C

### DIFF
--- a/src/ffi.md
+++ b/src/ffi.md
@@ -281,7 +281,7 @@ We'll create a C file to call the `hello_from_rust` function and compile it by `
 C file should look like:
 
 ```c
-int main() {
+int main(void) {
     hello_from_rust();
     return 0;
 }


### PR DESCRIPTION
As you may know, an empty parameter list can have [different semantics]
in C compared to a `(void)` parameter list. Also, while it's fine to
declare `main()` with an empty parameter list, it's implementation
defined as to whether it is acceptable.

Declare `main` with `(void)` so we use a standard-defined signature from
section 5.1.2.2.1 of C99.

[different semantics]: https://godbolt.org/z/fW66MsaMM