### PR TITLE
send-and-sync: it's -> its

### DIFF
--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -76,7 +76,7 @@ largely behave like an `&` or `&mut` into the collection.
 
 ## Example
 
-[`Box`][box-doc] is implemented as it's own special intrinsic type by the
+[`Box`][box-doc] is implemented as its own special intrinsic type by the
 compiler for [various reasons][box-is-special], but we can implement something
 with similar-ish behavior ourselves to see an example of when it is sound to
 implement Send and Sync. Let's call it a `Carton`.


### PR DESCRIPTION
Fixes a typo.