### PR TITLE
Fix a syntax error in leaking.md

### DIFF
--- a/src/leaking.md
+++ b/src/leaking.md
@@ -209,7 +209,7 @@ Usage looked like:
 ```rust,ignore
 let mut data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 {
-    let guards = vec![];
+    let mut guards = vec![];
     for x in &mut data {
         // Move the mutable reference into the closure, and execute
         // it on a different thread. The closure has a lifetime bound


### PR DESCRIPTION
`guards` should be mutable here:
https://github.com/rust-lang/nomicon/blob/9493715a6280a1f74be759c7e1ef9999b5d13e6f/src/leaking.md#L208-L232
