### PR TITLE
implement `IntoIterator` for `Vec`

### DIFF
--- a/src/vec/vec-drain.md
+++ b/src/vec/vec-drain.md
@@ -82,8 +82,10 @@ impl<T> Drop for IntoIter<T> {
     }
 }
 
-impl<T> Vec<T> {
-    pub fn into_iter(self) -> IntoIter<T> {
+impl<T> IntoIterator for Vec<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+    fn into_iter(self) -> IntoIter<T> {
         unsafe {
             let iter = RawValIter::new(&self);
 

--- a/src/vec/vec-final.md
+++ b/src/vec/vec-final.md
@@ -158,19 +158,6 @@ impl<T> Vec<T> {
         }
     }
 
-    pub fn into_iter(self) -> IntoIter<T> {
-        unsafe {
-            let iter = RawValIter::new(&self);
-            let buf = ptr::read(&self.buf);
-            mem::forget(self);
-
-            IntoIter {
-                iter: iter,
-                _buf: buf,
-            }
-        }
-    }
-
     pub fn drain(&mut self) -> Drain<T> {
         unsafe {
             let iter = RawValIter::new(&self);
@@ -205,6 +192,23 @@ impl<T> Deref for Vec<T> {
 impl<T> DerefMut for Vec<T> {
     fn deref_mut(&mut self) -> &mut [T] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr(), self.len) }
+    }
+}
+
+impl<T> IntoIterator for Vec<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+    fn into_iter(self) -> IntoIter<T> {
+        unsafe {
+            let iter = RawValIter::new(&self);
+            let buf = ptr::read(&self.buf);
+            mem::forget(self);
+
+            IntoIter {
+                iter: iter,
+                _buf: buf,
+            }
+        }
     }
 }
 

--- a/src/vec/vec-into-iter.md
+++ b/src/vec/vec-into-iter.md
@@ -57,8 +57,10 @@ And this is what we end up with for initialization:
 
 <!-- ignore: simplified code -->
 ```rust,ignore
-impl<T> Vec<T> {
-    pub fn into_iter(self) -> IntoIter<T> {
+impl<T> IntoIterator for Vec<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+    fn into_iter(self) -> IntoIter<T> {
         // Can't destructure Vec since it's Drop
         let ptr = self.ptr;
         let cap = self.cap;

--- a/src/vec/vec-raw.md
+++ b/src/vec/vec-raw.md
@@ -134,8 +134,10 @@ impl<T> Drop for IntoIter<T> {
     }
 }
 
-impl<T> Vec<T> {
-    pub fn into_iter(self) -> IntoIter<T> {
+impl<T> IntoIterator for Vec<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+    fn into_iter(self) -> IntoIter<T> {
         unsafe {
             // need to use ptr::read to unsafely move the buf out since it's
             // not Copy, and Vec implements Drop (so we can't destructure it).


### PR DESCRIPTION
It may be better to implement [`IntoIterator`](https://doc.rust-lang.org/core/iter/trait.IntoIterator.html "The Standard Library") for `Vec`.