### PR TITLE
Add an explanation shared to exclusive transmute

### DIFF
--- a/src/transmutes.md
+++ b/src/transmutes.md
@@ -19,7 +19,10 @@ boggling.
 * Transmute has an overloaded return type. If you do not specify the return type
   it may produce a surprising type to satisfy inference.
 
-* Transmuting an `&` to `&mut` is UB.
+* Transmuting an `&` to `&mut` is UB. While certain usages may *appear* safe,
+  note that the Rust optimizer is free to assume that a shared reference won't
+  change through its lifetime and thus such transmutation will run afoul of those
+  assumptions. So:
   * Transmuting an `&` to `&mut` is *always* UB.
   * No you can't do it.
   * No you're not special.


### PR DESCRIPTION
The current version mentions that "Transmuting an `&` to `&mut` is UB"
and then the sub-bullets (passionately!) dissuades people from doing so,
but without explaining a possible failure scenario. This change alludes
to the fact that such transmutation will run afoul of the assumptions
that the optimizer may legitimately make.