### PR TITLE
Rephrase improperly reduced borrows introduction

### DIFF
--- a/src/lifetime-mismatch.md
+++ b/src/lifetime-mismatch.md
@@ -76,7 +76,7 @@ care about, but the lifetime system is too coarse-grained to handle that.
 The following code fails to compile, because Rust sees that a variable, `map`,
 is borrowed twice, and can not infer that the first borrow stops to be needed
 before the second one occurs. This is caused by Rust conservatively falling back
-to using a whole scope for the first borow.  This will eventually get fixed.
+to using a whole scope for the first borow. This will eventually get fixed.
 
 ```rust,compile_fail
 # use std::collections::HashMap;

--- a/src/lifetime-mismatch.md
+++ b/src/lifetime-mismatch.md
@@ -73,9 +73,10 @@ care about, but the lifetime system is too coarse-grained to handle that.
 
 ## Improperly reduced borrows
 
-The following code fails to compile, because Rust doesn't understand that the borrow
-is no longer needed and conservatively falls back to using a whole scope for it.
-This will eventually get fixed.
+The following code fails to compile, because Rust sees that a variable, `map`,
+is borrowed twice, and can not infer that the first borrow stops to be needed
+before the second one occurs. This is caused by Rust conservatively falling back
+to using a whole scope for the first borow.  This will eventually get fixed.
 
 ```rust,compile_fail
 # use std::collections::HashMap;


### PR DESCRIPTION
The issue with the current version of this paragraph is that it refers to code
that will occur later. It can only be understood once we know what is borrowed
and when, which only becomes clear when the error message is shown.

With this new phrasing, I hope that the introduction prepares the reader to what
they'll find out.

Another solution would be to imitate the first example of this page. Introduce
the code with just "Given the following code:" and then comment why it
failed.