### PR TITLE
Introducing init/uninit before its use

### DIFF
--- a/src/checked-uninit.md
+++ b/src/checked-uninit.md
@@ -18,7 +18,10 @@ fn main() {
 ```
 
 This is based off of a basic branch analysis: every branch must assign a value
-to `x` before it is first used. Interestingly, Rust doesn't require the variable
+to `x` before it is first used. For short, we also say that "`x` is init" or
+"`x` is uninit".
+
+Interestingly, Rust doesn't require the variable
 to be mutable to perform a delayed initialization if every branch assigns
 exactly once. However the analysis does not take advantage of constant analysis
 or anything like that. So this compiles:


### PR DESCRIPTION
In this case, I believe the meaning is intuitive enough that the abbreviation
makes sens. However, I still prefer to introduce it explicitly. In particular
because, in drop-flags, I misintepreted "x was uninit". I thought that "uninit"
was a verb, so that something did uninit x. It is only after some thought that I
understood that it was not a passive sentence but a descriptive one, and that
"uninit" should be understood as an adjective.