### PR TITLE
Add test link to subtype

### DIFF
--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -452,3 +452,5 @@ struct MyType<'a, 'b, A: 'a, B: 'b, C, D, E, F, G, H, In, Out, Mixed> {
     k2: Mixed,              // invariant over Mixed, because invariance wins all conflicts
 }
 ```
+
+To debug variance of custom struct, see `src/test/ui/variance/variance-types.rs`.


### PR DESCRIPTION
I find src/test/ui/variance/variance-types.rs quite helpful in debugging variance.