### PR TITLE
Update lifetimes.md

### DIFF
--- a/src/lifetimes.md
+++ b/src/lifetimes.md
@@ -55,7 +55,7 @@ likely desugar to the following:
         let y: &'b i32 = &'b x;
         'c: {
             // ditto on 'c
-            let z: &'c i32 = &'c y;
+            let z: &'c &'b i32 = &'c y; // "a reference to a reference to an i32" (with lifetimes annotated)
         }
     }
 }

--- a/src/lifetimes.md
+++ b/src/lifetimes.md
@@ -55,7 +55,7 @@ likely desugar to the following:
         let y: &'b i32 = &'b x;
         'c: {
             // ditto on 'c
-            let z: &'c &'b i32 = &'c y;
+            let z: &'c i32 = &'c y;
         }
     }
 }


### PR DESCRIPTION
Get rid of the obviously wrong (and potentially confusing) double lifetime annotation.  My guess as to the etiology is an errant copy-and-paste.