### PR TITLE
Grammar change for 3.4: Limits of Lifetimes (lifetime-mismatch.md)

### DIFF
--- a/src/lifetime-mismatch.md
+++ b/src/lifetime-mismatch.md
@@ -74,7 +74,7 @@ care about, but the lifetime system is too coarse-grained to handle that.
 ## Improperly reduced borrows
 
 The following code fails to compile, because Rust sees that a variable, `map`,
-is borrowed twice, and can not infer that the first borrow stops to be needed
+is borrowed twice, and can not infer that the first borrow ceases to be needed
 before the second one occurs. This is caused by Rust conservatively falling back
 to using a whole scope for the first borrow. This will eventually get fixed.
 


### PR DESCRIPTION
"[...] stops to be needed [...]" -> "[...] ceases to be needed [...]"