### PR TITLE
Discourage the use of transmute to construct invalid values

### DIFF
--- a/src/ffi.md
+++ b/src/ffi.md
@@ -659,7 +659,8 @@ Certain Rust types are defined to never be `null`. This includes references (`&T
 `&mut T`), boxes (`Box<T>`), and function pointers (`extern "abi" fn()`). When
 interfacing with C, pointers that might be `null` are often used, which would seem to
 require some messy `transmute`s and/or unsafe code to handle conversions to/from Rust types.
-However, the language provides a workaround.
+However, trying to construct/work with these invalid values **is undefined behavior**,
+so you should use the following workaround instead.
 
 As a special case, an `enum` is eligible for the "nullable pointer optimization" if it contains
 exactly two variants, one of which contains no data and the other contains a field of one of the


### PR DESCRIPTION
Creating null values of non-null types with transmute is undefined behavior, and the nomicon doesn't explicitly say that in the ["nullable pointer optimization"](https://doc.rust-lang.org/nomicon/ffi.html#the-nullable-pointer-optimization) chapter. Hopefully this comment will discourage the use of transmute in this case a little bit more.