### PR TITLE
borrow-splitting: Use `take` instead of `replace`

### DIFF
--- a/src/borrow-splitting.md
+++ b/src/borrow-splitting.md
@@ -159,7 +159,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     type Item = &'a mut T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let slice = mem::replace(&mut self.0, &mut []);
+        let slice = mem::take(&mut self.0);
         if slice.is_empty() { return None; }
 
         let (l, r) = slice.split_at_mut(1);
@@ -170,7 +170,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
 impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let slice = mem::replace(&mut self.0, &mut []);
+        let slice = mem::take(&mut self.0);
         if slice.is_empty() { return None; }
 
         let new_len = slice.len() - 1;


### PR DESCRIPTION
Clippy complains with this lint on the old code: https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default