### PR TITLE
Fix typo in dropck documentation

### DIFF
--- a/src/dropck.md
+++ b/src/dropck.md
@@ -250,7 +250,7 @@ fn main() {
         inspector: None,
         days: Box::new(1),
     };
-    world.inspector = Some(Inspector(&world.days, "gatget"));
+    world.inspector = Some(Inspector(&world.days, "gadget"));
 }
 ```
 


### PR DESCRIPTION
This fixes `gatget` to say `gadget`