### PR TITLE
Fixes double bug in Send-Sync example

### DIFF
--- a/src/send-and-sync.md
+++ b/src/send-and-sync.md
@@ -94,6 +94,7 @@ to the heap.
 use std::{
     mem::{align_of, size_of},
     ptr,
+    cmp::max,
 };
 
 struct Carton<T>(ptr::NonNull<T>);
@@ -105,8 +106,8 @@ impl<T> Carton<T> {
         let mut memptr: *mut T = ptr::null_mut();
         unsafe {
             let ret = libc::posix_memalign(
-                (&mut memptr).cast(),
-                align_of::<T>(),
+                (&mut memptr as *mut *mut T).cast(),
+                max(align_of::<T>(), size_of::<usize>()),
                 size_of::<T>()
             );
             assert_eq!(ret, 0, "Failed to allocate or invalid alignment");


### PR DESCRIPTION
Fixes double bug in the call to libc::posix_memalign which causes SIGSEGV due to incorrect pointer parameter and EINVAL (retval=22) due to incorrect alignment when size of T is less then size of usize.