### PR TITLE
Update to 2021 edition

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -32,4 +32,4 @@ git-repository-url = "https://github.com/rust-lang/nomicon"
 "./arc.html" = "./arc-mutex/arc.html"
 
 [rust]
-edition = "2018"
+edition = "2021"

--- a/src/intro.md
+++ b/src/intro.md
@@ -39,7 +39,7 @@ Topics that are within the scope of this book include: the meaning of (un)safety
 
 The Rustonomicon is not a place to exhaustively describe the semantics and guarantees of every single API in the standard library, nor is it a place to exhaustively describe every feature of Rust.
 
-Unless otherwise noted, Rust code in this book uses the Rust 2018 edition.
+Unless otherwise noted, Rust code in this book uses the Rust 2021 edition.
 
 [trpl]: ../book/index.html
 [ref]: ../reference/index.html


### PR DESCRIPTION
Is there any reason it is 2018 instead of 2021? Everything passed `mdbook test`