### PR TITLE
Minor improvements

### DIFF
--- a/src/atomics.md
+++ b/src/atomics.md
@@ -76,7 +76,7 @@ For instance, say we convince the compiler to emit this logic:
 ```text
 initial state: x = 0, y = 1
 
-THREAD 1        THREAD2
+THREAD 1        THREAD 2
 y = 3;          if x == 1 {
 x = 1;              y *= 2;
                 }

--- a/src/exception-safety.md
+++ b/src/exception-safety.md
@@ -161,9 +161,9 @@ impl<'a, T> Hole<'a, T> {
         unsafe {
             let elt = ptr::read(&data[pos]);
             Hole {
-                data: data,
+                data,
                 elt: Some(elt),
-                pos: pos,
+                pos,
             }
         }
     }

--- a/src/leaking.md
+++ b/src/leaking.md
@@ -134,10 +134,10 @@ impl<T> Rc<T> {
             // Wouldn't it be nice if heap::allocate worked like this?
             let ptr = heap::allocate::<RcBox<T>>();
             ptr::write(ptr, RcBox {
-                data: data,
+                data,
                 ref_count: 1,
             });
-            Rc { ptr: ptr }
+            Rc { ptr }
         }
     }
 

--- a/src/leaking.md
+++ b/src/leaking.md
@@ -194,7 +194,7 @@ pub fn scoped<'a, F>(f: F) -> JoinGuard<'a>
 ```
 
 Here `f` is some closure for the other thread to execute. Saying that
-`F: Send +'a` is saying that it closes over data that lives for `'a`, and it
+`F: Send + 'a` is saying that it closes over data that lives for `'a`, and it
 either owns that data or the data was Sync (implying `&data` is Send).
 
 Because JoinGuard has a lifetime, it keeps all the data it closes over

--- a/src/vec/vec-final.md
+++ b/src/vec/vec-final.md
@@ -23,7 +23,7 @@ impl<T> RawVec<T> {
         // `NonNull::dangling()` doubles as "unallocated" and "zero-sized allocation"
         RawVec {
             ptr: NonNull::dangling(),
-            cap: cap,
+            cap,
         }
     }
 

--- a/src/vec/vec-zsts.md
+++ b/src/vec/vec-zsts.md
@@ -39,7 +39,7 @@ impl<T> RawVec<T> {
         // `NonNull::dangling()` doubles as "unallocated" and "zero-sized allocation"
         RawVec {
             ptr: NonNull::dangling(),
-            cap: cap,
+            cap,
         }
     }
 


### PR DESCRIPTION
- Add missing space in lifetime notation (Leaking page)
- Use shorthand notation for field initialization across `new` methods, just like [Arc does currently](https://github.com/rust-lang/nomicon/blob/master/src/arc-mutex/arc-base.md)
- Add missing space in threads execution example (Atomics page)