### PR TITLE
Minor improvements to Vec

### DIFF
--- a/src/vec/vec-drain.md
+++ b/src/vec/vec-drain.md
@@ -93,7 +93,7 @@ impl<T> IntoIterator for Vec<T> {
             mem::forget(self);
 
             IntoIter {
-                iter: iter,
+                iter,
                 _buf: buf,
             }
         }
@@ -144,7 +144,7 @@ impl<T> Vec<T> {
             self.len = 0;
 
             Drain {
-                iter: iter,
+                iter,
                 vec: PhantomData,
             }
         }

--- a/src/vec/vec-drain.md
+++ b/src/vec/vec-drain.md
@@ -135,18 +135,16 @@ impl<'a, T> Drop for Drain<'a, T> {
 
 impl<T> Vec<T> {
     pub fn drain(&mut self) -> Drain<T> {
-        unsafe {
-            let iter = RawValIter::new(&self);
+        let iter = unsafe { RawValIter::new(&self) };
 
-            // this is a mem::forget safety thing. If Drain is forgotten, we just
-            // leak the whole Vec's contents. Also we need to do this *eventually*
-            // anyway, so why not do it now?
-            self.len = 0;
+        // this is a mem::forget safety thing. If Drain is forgotten, we just
+        // leak the whole Vec's contents. Also we need to do this *eventually*
+        // anyway, so why not do it now?
+        self.len = 0;
 
-            Drain {
-                iter,
-                vec: PhantomData,
-            }
+        Drain {
+            iter,
+            vec: PhantomData,
         }
     }
 }

--- a/src/vec/vec-final.md
+++ b/src/vec/vec-final.md
@@ -127,7 +127,7 @@ impl<T> Vec<T> {
 
     pub fn insert(&mut self, index: usize, elem: T) {
         assert!(index <= self.len, "index out of bounds");
-        if self.cap() == self.len {
+        if self.len == self.cap() {
             self.buf.grow();
         }
 

--- a/src/vec/vec-final.md
+++ b/src/vec/vec-final.md
@@ -166,7 +166,7 @@ impl<T> Vec<T> {
             self.len = 0;
 
             Drain {
-                iter: iter,
+                iter,
                 vec: PhantomData,
             }
         }
@@ -203,7 +203,7 @@ impl<T> IntoIterator for Vec<T> {
             mem::forget(self);
 
             IntoIter {
-                iter: iter,
+                iter,
                 _buf: buf,
             }
         }

--- a/src/vec/vec-final.md
+++ b/src/vec/vec-final.md
@@ -138,14 +138,17 @@ impl<T> Vec<T> {
                 self.len - index,
             );
             ptr::write(self.ptr().add(index), elem);
-            self.len += 1;
         }
+
+        self.len += 1;
     }
 
     pub fn remove(&mut self, index: usize) -> T {
         assert!(index < self.len, "index out of bounds");
+
+        self.len -= 1;
+
         unsafe {
-            self.len -= 1;
             let result = ptr::read(self.ptr().add(index));
             ptr::copy(
                 self.ptr().add(index + 1),
@@ -157,18 +160,16 @@ impl<T> Vec<T> {
     }
 
     pub fn drain(&mut self) -> Drain<T> {
-        unsafe {
-            let iter = RawValIter::new(&self);
+        let iter = unsafe { RawValIter::new(&self) };
 
-            // this is a mem::forget safety thing. If Drain is forgotten, we just
-            // leak the whole Vec's contents. Also we need to do this *eventually*
-            // anyway, so why not do it now?
-            self.len = 0;
+        // this is a mem::forget safety thing. If Drain is forgotten, we just
+        // leak the whole Vec's contents. Also we need to do this *eventually*
+        // anyway, so why not do it now?
+        self.len = 0;
 
-            Drain {
-                iter,
-                vec: PhantomData,
-            }
+        Drain {
+            iter,
+            vec: PhantomData,
         }
     }
 }
@@ -197,15 +198,15 @@ impl<T> IntoIterator for Vec<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
     fn into_iter(self) -> IntoIter<T> {
-        unsafe {
-            let iter = RawValIter::new(&self);
-            let buf = ptr::read(&self.buf);
-            mem::forget(self);
+        let (iter, buf) = unsafe {
+            (RawValIter::new(&self), ptr::read(&self.buf))
+        };
 
-            IntoIter {
-                iter,
-                _buf: buf,
-            }
+        mem::forget(self);
+
+        IntoIter {
+            iter,
+            _buf: buf,
         }
     }
 }

--- a/src/vec/vec-insert-remove.md
+++ b/src/vec/vec-insert-remove.md
@@ -18,7 +18,7 @@ pub fn insert(&mut self, index: usize, elem: T) {
     // Note: `<=` because it's valid to insert after everything
     // which would be equivalent to push.
     assert!(index <= self.len, "index out of bounds");
-    if self.cap == self.len { self.grow(); }
+    if self.len == self.cap { self.grow(); }
 
     unsafe {
         // ptr::copy(src, dest, len): "copy from src to dest len elems"

--- a/src/vec/vec-insert-remove.md
+++ b/src/vec/vec-insert-remove.md
@@ -28,8 +28,9 @@ pub fn insert(&mut self, index: usize, elem: T) {
             self.len - index,
         );
         ptr::write(self.ptr.as_ptr().add(index), elem);
-        self.len += 1;
     }
+
+    self.len += 1;
 }
 ```
 

--- a/src/vec/vec-into-iter.md
+++ b/src/vec/vec-into-iter.md
@@ -68,18 +68,16 @@ impl<T> IntoIterator for Vec<T> {
         let cap = vec.cap;
         let len = vec.len;
 
-        unsafe {
-            IntoIter {
-                buf: ptr,
-                cap,
-                start: ptr.as_ptr(),
-                end: if cap == 0 {
-                    // can't offset off this pointer, it's not allocated!
-                    ptr.as_ptr()
-                } else {
-                    ptr.as_ptr().add(len)
-                },
-            }
+        IntoIter {
+            buf: ptr,
+            cap,
+            start: ptr.as_ptr(),
+            end: if cap == 0 {
+                // can't offset off this pointer, it's not allocated!
+                ptr.as_ptr()
+            } else {
+                unsafe { ptr.as_ptr().add(len) }
+            },
         }
     }
 }

--- a/src/vec/vec-into-iter.md
+++ b/src/vec/vec-into-iter.md
@@ -71,7 +71,7 @@ impl<T> IntoIterator for Vec<T> {
         unsafe {
             IntoIter {
                 buf: ptr,
-                cap: cap,
+                cap,
                 start: ptr.as_ptr(),
                 end: if cap == 0 {
                     // can't offset off this pointer, it's not allocated!

--- a/src/vec/vec-layout.md
+++ b/src/vec/vec-layout.md
@@ -40,7 +40,6 @@ we get the same results as using `Unique<T>`:
 
 ```rust
 use std::ptr::NonNull;
-use std::marker::PhantomData;
 
 pub struct Vec<T> {
     ptr: NonNull<T>,

--- a/src/vec/vec-raw.md
+++ b/src/vec/vec-raw.md
@@ -131,23 +131,21 @@ impl<T> IntoIterator for Vec<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
     fn into_iter(self) -> IntoIter<T> {
-        unsafe {
-            // need to use ptr::read to unsafely move the buf out since it's
-            // not Copy, and Vec implements Drop (so we can't destructure it).
-            let buf = ptr::read(&self.buf);
-            let len = self.len;
-            mem::forget(self);
+        // need to use ptr::read to unsafely move the buf out since it's
+        // not Copy, and Vec implements Drop (so we can't destructure it).
+        let buf = unsafe { ptr::read(&self.buf) };
+        let len = self.len;
+        mem::forget(self);
 
-            IntoIter {
-                start: buf.ptr.as_ptr(),
-                end: if buf.cap == 0 {
-                    // can't offset off of a pointer unless it's part of an allocation
-                    buf.ptr.as_ptr()
-                } else {
-                    buf.ptr.as_ptr().add(len)
-                },
-                _buf: buf,
-            }
+        IntoIter {
+            start: buf.ptr.as_ptr(),
+            end: if buf.cap == 0 {
+                // can't offset off of a pointer unless it's part of an allocation
+                buf.ptr.as_ptr()
+            } else {
+                unsafe { buf.ptr.as_ptr().add(len) }
+            },
+            _buf: buf,
         }
     }
 }


### PR DESCRIPTION
- Make both comparisons that call `grow()` use the same order of `len` and `cap`
- Use shorthand notation for field initialization, just as its being used across the book's codebase
- Remove unused import (PhantomData) in the Layout page
- Limit scope of `unsafe` usage to only where it's really needed

I copied the "Final Code" page into a local `cargo new --lib` folder and it compiled and ran tests successfully :heavy_check_mark: (edit: I forgot the CI is running doc tests lol)