### PR TITLE
remove 'fail to call destructors' from okay-list

### DIFF
--- a/src/what-unsafe-does.md
+++ b/src/what-unsafe-does.md
@@ -71,7 +71,6 @@ Rust considers it "safe" to:
 * Deadlock
 * Have a [race condition][race]
 * Leak memory
-* Fail to call destructors
 * Overflow integers
 * Abort the program
 * Delete the production database


### PR DESCRIPTION
This would need a bunch of caveats: when data is pinned, it *is* unsound to not call the destructors (pinning wasn't a thing yet when the nomicon got written); also code can rely on the destructors in its own stack frame to be executed if the stack frame ever gets popped (i.e., longjmp-ing over the stack frame is not okay).