### PR TITLE
Rename generic type parameter in Subtyping chapter

### DIFF
--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -274,7 +274,7 @@ To see why `fn(T) -> U` should be covariant over `U`, consider the following sig
 fn get_str() -> &'a str;
 ```
 
-This function claims to produce a `str` bound by some liftime `'a`. As such, it is perfectly valid to
+This function claims to produce a `str` bound by some lifetime `'a`. As such, it is perfectly valid to
 provide a function with the following signature instead:
 
 <!-- ignore: simplified code -->


### PR DESCRIPTION
Like several issues (#124, #262, #305, #339) have pointed before, the chapter “Subtyping and Variance” can easily become confusing. I have experienced that as well, and I have noticed that this was partially caused by `T` used both in `&'a T` and as the `&'a T` itself in `&mut &'a T` (thus written `&mut T`).

To make things clearer, this PR renames the generic type parameter of the function `R`, since it is intended to be a reference in the examples. `&'a T` stays unchanged, but `R` is used when `&'a T` itself is intended; for instance, the more generic variant of `&mut &'a T` is thus `&mut R`.

I have also slightly changed some explanations to clarify them and take into account this new naming.