### PR TITLE
Ignore a doctest that will be broken by a stabilization

### DIFF
--- a/src/exotic-sizes.md
+++ b/src/exotic-sizes.md
@@ -139,7 +139,7 @@ other is still Undefined Behavior).
 
 The following *could* also compile:
 
-```rust,compile_fail
+```ignore(this is about to change)
 enum Void {}
 
 let res: Result<u32, Void> = Ok(0);


### PR DESCRIPTION
Over at https://github.com/rust-lang/rust/pull/122792, I'm proposing to stabilize a feature that will allow `let Ok(x) = result;` to compile for `result: Result<T, Void>`. Problem is, the nomicon contains a doctest that asserts that this doesn't compile. Which breaks CI on my stabilization PR :grin:.

I don't know if there's a standard procedure for this, so I thought I'd ignore the test here first, wait for submodule update on the rustc side, which will allow my PR to pass CI. If it gets merged we can re-enable the doctest and update it. If the stabilization doesn't go through we can just revert this. Is that sensible? 