### PR TITLE
Use `()` instead of `[u8; 0]` in opaque type

### DIFF
--- a/src/ffi.md
+++ b/src/ffi.md
@@ -891,13 +891,13 @@ To do this in Rust, let’s create our own opaque types:
 ```rust
 #[repr(C)]
 pub struct Foo {
-    _data: [u8; 0],
+    _data: (),
     _marker:
         core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
 }
 #[repr(C)]
 pub struct Bar {
-    _data: [u8; 0],
+    _data: (),
     _marker:
         core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
 }


### PR DESCRIPTION
There once was [a comment](https://github.com/rust-lang/nomicon/commit/90811705ca28c1e2a7e85315a154c464c0f42c5b#diff-ed2118bc56f30badbb9126d150cd476a09dafe0e1f9a4f310b6c86da2589b4b0L757-L758) in the opaque structs section of the FFI chapter which explained that the empty array is used to avoid a warning around  `()` in FFI. Since Rust 1.72, the compiler [no longer warns](https://github.com/rust-lang/rust/pull/113457/commits/24f90fdd2654e9c5437a684d3a72a4e70826a985) about using `()` in FFI.

This PR swaps `[u8; 0]` for `()` in the example opaque structs to avoid any future confusion.