### PR TITLE
races: Clarify a “mostly” that might be misread

### DIFF
--- a/src/races.md
+++ b/src/races.md
@@ -7,7 +7,7 @@ Safe Rust guarantees an absence of data races, which are defined as:
 * one or more of them is unsynchronized
 
 A data race has Undefined Behavior, and is therefore impossible to perform in
-Safe Rust. Data races are *mostly* prevented through Rust's ownership system:
+Safe Rust. Data races are prevented *mostly* through Rust's ownership system alone:
 it's impossible to alias a mutable reference, so it's impossible to perform a
 data race. Interior mutability makes this more complicated, which is largely why
 we have the Send and Sync traits (see the next section for more on this).


### PR DESCRIPTION
One might carelessly misread a sentence that begins “data races are *mostly* prevented” as suggesting that Rust fails to prevent some data races.  Clarify the intended reading.