### PR TITLE
races.md: data race -> race condition to violate memory safety

### DIFF
--- a/src/races.md
+++ b/src/races.md
@@ -60,8 +60,8 @@ thread::spawn(move || {
 println!("{}", data[idx.load(Ordering::SeqCst)]);
 ```
 
-We can cause a data race if we instead do the bound check in advance, and then
-unsafely access the data with an unchecked value:
+We can cause a race condition to violate memory safety if we instead do the bound
+check in advance, and then unsafely access the data with an unchecked value:
 
 ```rust,no_run
 use std::thread;


### PR DESCRIPTION
The first example shows that you "can't violate memory safety with safe Rust" and the second example shows that you "can violate memory safety with unsafe Rust".

The second example does not demonstrate a data race since there is only one thread touching `data`.

Fixes #466 