### PR TITLE
Fix accidental inline HTML in Markdown

### DIFF
--- a/src/arc-mutex/arc-drop.md
+++ b/src/arc-mutex/arc-drop.md
@@ -51,7 +51,7 @@ implementation of `Arc`][3]:
 > > "acquire" operation before deleting the object.
 >
 > In particular, while the contents of an Arc are usually immutable, it's
-> possible to have interior writes to something like a Mutex<T>. Since a Mutex
+> possible to have interior writes to something like a `Mutex<T>`. Since a Mutex
 > is not acquired when it is deleted, we can't rely on its synchronization logic
 > to make writes in thread A visible to a destructor running in thread B.
 >


### PR DESCRIPTION
"Mutex\<T\>" in markdown is interpreted as "Mutex" followed by an inline HTML tag `<T>` and therefore rendered as "Mutex" without the "\<T\>" ([playground](https://spec.commonmark.org/dingus/?text=%3E%20In%20particular%2C%20while%20the%20contents%20of%20an%20Arc%20are%20usually%20immutable%2C%20it%27s%0A%3E%20possible%20to%20have%20interior%20writes%20to%20something%20like%20a%20Mutex%3CT%3E.%20Since%20a%20Mutex%0A%3E%20is%20not%20acquired%20when%20it%20is%20deleted%2C%20we%20can%27t%20rely%20on%20its%20synchronization%20logic%0A%3E%20to%20make%20writes%20in%20thread%20A%20visible%20to%20a%20destructor%20running%20in%20thread%20B.%0A)).