### PR TITLE
Update guidance on uninitialized fields to use &raw mut instead of addr_of_mut!

### DIFF
--- a/src/unchecked-uninit.md
+++ b/src/unchecked-uninit.md
@@ -134,7 +134,7 @@ to compute the address of array index `idx`. This relies on
 how arrays are laid out in memory.
 * For a struct, however, in general we do not know how it is laid out, and we
 also cannot use `&mut base_ptr.field` as that would be creating a
-reference. So, you must carefully use the [`addr_of_mut`] macro. This creates
+reference. So, you must carefully use the [raw reference][raw_reference] syntax. This creates
 a raw pointer to the field without creating an intermediate reference:
 
 ```rust
@@ -147,7 +147,7 @@ struct Demo {
 let mut uninit = MaybeUninit::<Demo>::uninit();
 // `&uninit.as_mut().field` would create a reference to an uninitialized `bool`,
 // and thus be Undefined Behavior!
-let f1_ptr = unsafe { ptr::addr_of_mut!((*uninit.as_mut_ptr()).field) };
+let f1_ptr = unsafe { &raw mut (*uninit.as_mut_ptr()).field };
 unsafe { f1_ptr.write(true); }
 
 let init = unsafe { uninit.assume_init() };
@@ -167,7 +167,7 @@ it around at all, be sure to be *really* careful.
 [`MaybeUninit`]: ../core/mem/union.MaybeUninit.html
 [assume_init]: ../core/mem/union.MaybeUninit.html#method.assume_init
 [`ptr`]: ../core/ptr/index.html
-[`addr_of_mut`]: ../core/ptr/macro.addr_of_mut.html
+[raw_reference]: ../reference/types/pointer.html#r-type.pointer.raw.constructor
 [`write`]: ../core/ptr/fn.write.html
 [`copy`]: ../std/ptr/fn.copy.html
 [`copy_nonoverlapping`]: ../std/ptr/fn.copy_nonoverlapping.html


### PR DESCRIPTION
The doc page on [addr_of_mut](https://doc.rust-lang.org/std/ptr/macro.addr_of_mut.html) and [addr_of](https://doc.rust-lang.org/std/ptr/macro.addr_of.html) state that the macros are soft deprecated in favor of &raw mut/&raw const.