### PR TITLE
remove `rust-intrinsic` ABI

### DIFF
--- a/src/ffi.md
+++ b/src/ffi.md
@@ -590,7 +590,6 @@ are:
 * `vectorcall`
 This is currently hidden behind the `abi_vectorcall` gate and is subject to change.
 * `Rust`
-* `rust-intrinsic`
 * `system`
 * `C`
 * `win64`


### PR DESCRIPTION
The rust-intrinsic ABI has been removed from the compiler in rust-lang/rust#139455 as part of rust-lang/rust#132735