### PR TITLE
Added range for vec.drain call

### DIFF
--- a/src/leaking.md
+++ b/src/leaking.md
@@ -75,7 +75,7 @@ let mut vec = vec![Box::new(0); 4];
 
 {
     // start draining, vec can no longer be accessed
-    let mut drainer = vec.drain(..);
+    let mut drainer = vec.drain(..3);
 
     // pull out two elements and immediately drop them
     drainer.next();


### PR DESCRIPTION
Without a range, the length of `vec` after using the drainer is zero anyways, even without forgetting the drainer.