### PR TITLE
Fix code sample output in unchecked-uninit.md

### DIFF
--- a/src/unchecked-uninit.md
+++ b/src/unchecked-uninit.md
@@ -43,7 +43,7 @@ let x = {
     unsafe { mem::transmute::<_, [Box<u32>; SIZE]>(x) }
 };
 
-dbg!(x);
+println!("{x:?}");
 ```
 
 This code proceeds in three steps:


### PR DESCRIPTION
`dbg!()` prints to stderr, which I assume is the reason there is no visible output when running the example in the book. By using `println!()` instead, the output becomes visible.