### PR TITLE
Add arrays as not FFI-safe in `other-reprs.md`

### DIFF
--- a/src/other-reprs.md
+++ b/src/other-reprs.md
@@ -30,6 +30,8 @@ says they should still consume a byte of space.
 * DST pointers (wide pointers) and tuples are not a concept
   in C, and as such are never FFI-safe.
 
+* Raw arrays of types are not FFI-safe.
+
 * Enums with fields also aren't a concept in C or C++, but a valid bridging
   of the types [is defined][really-tagged].
 


### PR DESCRIPTION
Raw arrays are not FFI-safe, even though they are sized. I think this should be mentioned in the Nomicon.