### PR TITLE
`#[may_dangle]` types can only be dropped, not moved

### DIFF
--- a/src/dropck.md
+++ b/src/dropck.md
@@ -260,7 +260,7 @@ compiler is not checking the implicit assertion that no potentially expired data
 
 The attribute can be applied to any number of lifetime and type parameters. In
 the following example, we assert that we access no data behind a reference of
-lifetime `'b` and that the only uses of `T` will be moves or drops, but omit
+lifetime `'b` and that the only uses of `T` will be drops, but omit
 the attribute from `'a` and `U`, because we do access data with that lifetime
 and that type:
 


### PR DESCRIPTION
Moving a `#[may_dangle]` type in `Drop::drop` asserts the validity of references stored in that type, which is unsound. For example, the following code is UB according to Miri:

```rust
#![feature(dropck_eyepatch)]
#![allow(unused)]

struct Thing<T>(Option<T>);

unsafe impl<#[may_dangle] T> Drop for Thing<T> {
    fn drop(&mut self) {
        let _ = self.0.take();
    }
}

fn main() {
    let thing;
    {
        let a = 1;
        thing = Thing(Some(&a));
    }
    // thing is dropped here
}
```