### PR TITLE
review comment: dropck analysis is *not* trivial

### DIFF
--- a/src/dropck.md
+++ b/src/dropck.md
@@ -213,7 +213,7 @@ strictly outlive that value.
 The precise rules that govern drop checking may be less restrictive in
 the future.
 
-The current analysis is deliberately conservative and trivial; it forces all
+The current analysis is deliberately conservative; it forces all
 borrowed data in a value to outlive that value, which is certainly sound.
 
 Future versions of the language may make the analysis more precise, to


### PR DESCRIPTION
It was [committed](https://github.com/rust-lang/nomicon/commit/a8362b6890cc8c77462423d183e7fb110bcc556f) seven years ago that dropck analysis was trivial. However this is outdated and [certainly no longer the case](https://doc.rust-lang.org/std/ops/trait.Drop.html#drop-check). This PR partially reverts that documentation comment.