### PR TITLE
Fix unknown field `author` error when building the book

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,5 +1,5 @@
 [book]
-author = "The Rust Project Developers"
+authors = ["The Rust Project Developers"]
 title = "The Rustonomicon"
 description = "The Dark Arts of Advanced and Unsafe Rust Programming"
 


### PR DESCRIPTION
using mdbook in main (v0.5.x)

```log
2025-08-18 19:56:41 [ERROR] (mdbook_core::utils): Error: Invalid configuration file
2025-08-18 19:56:41 [ERROR] (mdbook_core::utils):       Caused By: TOML parse error at line 2, column 1
  |
2 | author = "The Rust Project Developers"
  | ^^^^^^
unknown field `author`, expected one of `title`, `authors`, `description`, `src`, `language`, `text-direction`
```