### PR TITLE
Add missing "C" ABI to FFI example code

### DIFF
--- a/src/ffi.md
+++ b/src/ffi.md
@@ -90,7 +90,7 @@ The `extern` block can be extended to cover the entire snappy API:
 use libc::{c_int, size_t};
 
 #[link(name = "snappy")]
-unsafe extern {
+unsafe extern "C" {
     fn snappy_compress(input: *const u8,
                        input_length: size_t,
                        compressed: *mut u8,


### PR DESCRIPTION
In the "[Calling foreign functions](https://doc.rust-lang.org/nomicon/ffi.html#calling-foreign-functions)" section of the FFI chapter, an example `extern` block is given that reads like so:

```
#[link(name = "snappy")]
unsafe extern "C" {
    fn snappy_max_compressed_length(source_length: size_t) -> size_t;
}
```

This example is then expanded upon later in the section, with the following code:

```
#[link(name = "snappy")]
unsafe extern {
    fn snappy_compress(input: *const u8,
                       input_length: size_t,
                       compressed: *mut u8,
                       compressed_length: *mut size_t) -> c_int;
    fn snappy_uncompress(compressed: *const u8,
                         compressed_length: size_t,
                         uncompressed: *mut u8,
                         uncompressed_length: *mut size_t) -> c_int;
    fn snappy_max_compressed_length(source_length: size_t) -> size_t;
    fn snappy_uncompressed_length(compressed: *const u8,
                                  compressed_length: size_t,
                                  result: *mut size_t) -> c_int;
    fn snappy_validate_compressed_buffer(compressed: *const u8,
                                         compressed_length: size_t) -> c_int;
}
```

This expanded example is unfortunately missing the `"C"` ABI specification in the `extern` block declaration, which was present in the previous example. This PR adds the missing `"C"` ABI.